### PR TITLE
[feat/#14] 회원 로그인 서비스와 로그인 기능 구현시 사용할 어노테이션 구현

### DIFF
--- a/src/main/java/com/techeer/cokkiri/domain/user/controller/UserController.java
+++ b/src/main/java/com/techeer/cokkiri/domain/user/controller/UserController.java
@@ -1,0 +1,27 @@
+package com.techeer.cokkiri.domain.user.controller;
+
+import com.techeer.cokkiri.domain.user.entity.User;
+import com.techeer.cokkiri.domain.user.service.UserService;
+import com.techeer.cokkiri.global.result.ResultResponse;
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import static com.techeer.cokkiri.domain.user.controller.UserController.USER_API_URI;
+import static com.techeer.cokkiri.global.result.ResultCode.USER_REGISTRATION_SUCCESS;
+
+@RestController
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+@RequestMapping(USER_API_URI)
+public class UserController {
+  public static final String USER_API_URI = "/api/users";
+
+  private final UserService userService;
+
+  @PostMapping
+  public ResponseEntity<ResultResponse> registration(@RequestBody User user) {
+    userService.registrationUser(user);
+    return ResponseEntity.ok(ResultResponse.of(USER_REGISTRATION_SUCCESS));
+  }
+}

--- a/src/main/java/com/techeer/cokkiri/domain/user/controller/UserController.java
+++ b/src/main/java/com/techeer/cokkiri/domain/user/controller/UserController.java
@@ -1,5 +1,8 @@
 package com.techeer.cokkiri.domain.user.controller;
 
+import static com.techeer.cokkiri.domain.user.controller.UserController.USER_API_URI;
+import static com.techeer.cokkiri.global.result.ResultCode.USER_REGISTRATION_SUCCESS;
+
 import com.techeer.cokkiri.domain.user.entity.User;
 import com.techeer.cokkiri.domain.user.service.UserService;
 import com.techeer.cokkiri.global.result.ResultResponse;
@@ -7,9 +10,6 @@ import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-
-import static com.techeer.cokkiri.domain.user.controller.UserController.USER_API_URI;
-import static com.techeer.cokkiri.global.result.ResultCode.USER_REGISTRATION_SUCCESS;
 
 @RestController
 @RequiredArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/com/techeer/cokkiri/domain/user/exception/UnAuthorizedAccessException.java
+++ b/src/main/java/com/techeer/cokkiri/domain/user/exception/UnAuthorizedAccessException.java
@@ -1,8 +1,8 @@
 package com.techeer.cokkiri.domain.user.exception;
 
-import com.techeer.cokkiri.global.error.exception.BusinessException;
-
 import static com.techeer.cokkiri.global.error.ErrorCode.UNAUTHORIZED_ACCESS_ERROR;
+
+import com.techeer.cokkiri.global.error.exception.BusinessException;
 
 public class UnAuthorizedAccessException extends BusinessException {
   public UnAuthorizedAccessException() {

--- a/src/main/java/com/techeer/cokkiri/domain/user/exception/UnAuthorizedAccessException.java
+++ b/src/main/java/com/techeer/cokkiri/domain/user/exception/UnAuthorizedAccessException.java
@@ -1,0 +1,11 @@
+package com.techeer.cokkiri.domain.user.exception;
+
+import com.techeer.cokkiri.global.error.exception.BusinessException;
+
+import static com.techeer.cokkiri.global.error.ErrorCode.UNAUTHORIZED_ACCESS_ERROR;
+
+public class UnAuthorizedAccessException extends BusinessException {
+  public UnAuthorizedAccessException() {
+    super(UNAUTHORIZED_ACCESS_ERROR);
+  }
+}

--- a/src/main/java/com/techeer/cokkiri/domain/user/exception/UserNotFoundException.java
+++ b/src/main/java/com/techeer/cokkiri/domain/user/exception/UserNotFoundException.java
@@ -1,11 +1,11 @@
 package com.techeer.cokkiri.domain.user.exception;
 
-import com.techeer.cokkiri.global.error.exception.BusinessException;
-
 import static com.techeer.cokkiri.global.error.ErrorCode.USER_NOT_FOUND_ERROR;
 
+import com.techeer.cokkiri.global.error.exception.BusinessException;
+
 public class UserNotFoundException extends BusinessException {
-    public UserNotFoundException() {
-        super(USER_NOT_FOUND_ERROR);
-    }
+  public UserNotFoundException() {
+    super(USER_NOT_FOUND_ERROR);
+  }
 }

--- a/src/main/java/com/techeer/cokkiri/domain/user/exception/UserNotFoundException.java
+++ b/src/main/java/com/techeer/cokkiri/domain/user/exception/UserNotFoundException.java
@@ -1,0 +1,11 @@
+package com.techeer.cokkiri.domain.user.exception;
+
+import com.techeer.cokkiri.global.error.exception.BusinessException;
+
+import static com.techeer.cokkiri.global.error.ErrorCode.USER_NOT_FOUND_ERROR;
+
+public class UserNotFoundException extends BusinessException {
+    public UserNotFoundException() {
+        super(USER_NOT_FOUND_ERROR);
+    }
+}

--- a/src/main/java/com/techeer/cokkiri/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/techeer/cokkiri/domain/user/repository/UserRepository.java
@@ -1,0 +1,6 @@
+package com.techeer.cokkiri.domain.user.repository;
+
+import com.techeer.cokkiri.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {}

--- a/src/main/java/com/techeer/cokkiri/domain/user/service/LoginService.java
+++ b/src/main/java/com/techeer/cokkiri/domain/user/service/LoginService.java
@@ -1,11 +1,10 @@
 package com.techeer.cokkiri.domain.user.service;
 
 import com.techeer.cokkiri.domain.user.entity.User;
+import javax.servlet.http.HttpSession;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-
-import javax.servlet.http.HttpSession;
 
 @Service
 @RequiredArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/com/techeer/cokkiri/domain/user/service/LoginService.java
+++ b/src/main/java/com/techeer/cokkiri/domain/user/service/LoginService.java
@@ -1,0 +1,37 @@
+package com.techeer.cokkiri.domain.user.service;
+
+import com.techeer.cokkiri.domain.user.entity.User;
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import javax.servlet.http.HttpSession;
+
+@Service
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+public class LoginService {
+  private final HttpSession httpSession;
+  private final UserService userService;
+  public static final String USER_ID = "USER_ID";
+
+  public void login(long id) {
+    httpSession.setAttribute(USER_ID, id);
+  }
+
+  public void logout() {
+    httpSession.removeAttribute(USER_ID);
+  }
+
+  public User getLoginUser() {
+    Long memberId = (Long) httpSession.getAttribute(USER_ID);
+    return userService.findUserById(memberId);
+  }
+
+  public Long getLoginUserId() {
+    return (Long) httpSession.getAttribute(USER_ID);
+  }
+
+  public boolean isUserLogin() {
+    return getLoginUserId() != null;
+  }
+}

--- a/src/main/java/com/techeer/cokkiri/domain/user/service/UserService.java
+++ b/src/main/java/com/techeer/cokkiri/domain/user/service/UserService.java
@@ -1,0 +1,22 @@
+package com.techeer.cokkiri.domain.user.service;
+
+import com.techeer.cokkiri.domain.user.entity.User;
+import com.techeer.cokkiri.domain.user.exception.UserNotFoundException;
+import com.techeer.cokkiri.domain.user.repository.UserRepository;
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserService {
+  private final UserRepository userRepository;
+
+  public void registrationUser(User user) {
+    userRepository.save(user);
+  }
+
+  public User findUserById(long id) {
+    return userRepository.findById(id).orElseThrow(UserNotFoundException::new);
+  }
+}

--- a/src/main/java/com/techeer/cokkiri/global/annotation/LoginRequired.java
+++ b/src/main/java/com/techeer/cokkiri/global/annotation/LoginRequired.java
@@ -1,0 +1,9 @@
+package com.techeer.cokkiri.global.annotation;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+/** 로그인 상태인지 체크해주는 어노테이션 */
+public @interface LoginRequired {}

--- a/src/main/java/com/techeer/cokkiri/global/annotation/LoginUser.java
+++ b/src/main/java/com/techeer/cokkiri/global/annotation/LoginUser.java
@@ -1,0 +1,9 @@
+package com.techeer.cokkiri.global.annotation;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+/** 로그인 된 사용자 정보를 바인딩 해주는 어노테이션 */
+public @interface LoginUser {}

--- a/src/main/java/com/techeer/cokkiri/global/config/WebConfig.java
+++ b/src/main/java/com/techeer/cokkiri/global/config/WebConfig.java
@@ -2,27 +2,26 @@ package com.techeer.cokkiri.global.config;
 
 import com.techeer.cokkiri.global.interceptor.LoginInterceptor;
 import com.techeer.cokkiri.global.resolver.LoginUserArgumentResolver;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
-import java.util.List;
-
 @Configuration
 @RequiredArgsConstructor
 public class WebConfig implements WebMvcConfigurer {
-    private final LoginInterceptor loginInterceptor;
-    private final LoginUserArgumentResolver loginUserArgumentResolver;
+  private final LoginInterceptor loginInterceptor;
+  private final LoginUserArgumentResolver loginUserArgumentResolver;
 
-    @Override
-    public void addInterceptors(InterceptorRegistry registry) {
-        registry.addInterceptor(loginInterceptor);
-    }
+  @Override
+  public void addInterceptors(InterceptorRegistry registry) {
+    registry.addInterceptor(loginInterceptor);
+  }
 
-    @Override
-    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
-        resolvers.add(loginUserArgumentResolver);
-    }
+  @Override
+  public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+    resolvers.add(loginUserArgumentResolver);
+  }
 }

--- a/src/main/java/com/techeer/cokkiri/global/config/WebConfig.java
+++ b/src/main/java/com/techeer/cokkiri/global/config/WebConfig.java
@@ -1,0 +1,28 @@
+package com.techeer.cokkiri.global.config;
+
+import com.techeer.cokkiri.global.interceptor.LoginInterceptor;
+import com.techeer.cokkiri.global.resolver.LoginUserArgumentResolver;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebConfig implements WebMvcConfigurer {
+    private final LoginInterceptor loginInterceptor;
+    private final LoginUserArgumentResolver loginUserArgumentResolver;
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(loginInterceptor);
+    }
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(loginUserArgumentResolver);
+    }
+}

--- a/src/main/java/com/techeer/cokkiri/global/error/ErrorCode.java
+++ b/src/main/java/com/techeer/cokkiri/global/error/ErrorCode.java
@@ -14,6 +14,8 @@ public enum ErrorCode {
   // 예시
   // User 도메인
   EXAMPLE_USER_ERROR(400, "U001", "테스트용 예시 에러코드"),
+  USER_NOT_FOUND_ERROR(400, "U002", "사용자를 찾을 수 없음"),
+  UNAUTHORIZED_ACCESS_ERROR(400, "U003", "승인되지 않은 접근"),
   ;
 
   private final int status;

--- a/src/main/java/com/techeer/cokkiri/global/interceptor/LoginInterceptor.java
+++ b/src/main/java/com/techeer/cokkiri/global/interceptor/LoginInterceptor.java
@@ -3,14 +3,13 @@ package com.techeer.cokkiri.global.interceptor;
 import com.techeer.cokkiri.domain.user.exception.UnAuthorizedAccessException;
 import com.techeer.cokkiri.domain.user.service.LoginService;
 import com.techeer.cokkiri.global.annotation.LoginRequired;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.web.method.HandlerMethod;
 import org.springframework.web.servlet.HandlerInterceptor;
-
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 
 @Component
 @RequiredArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/com/techeer/cokkiri/global/interceptor/LoginInterceptor.java
+++ b/src/main/java/com/techeer/cokkiri/global/interceptor/LoginInterceptor.java
@@ -1,0 +1,37 @@
+package com.techeer.cokkiri.global.interceptor;
+
+import com.techeer.cokkiri.domain.user.exception.UnAuthorizedAccessException;
+import com.techeer.cokkiri.domain.user.service.LoginService;
+import com.techeer.cokkiri.global.annotation.LoginRequired;
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.method.HandlerMethod;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+@Component
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+// 인터셉터를 통해 로그인 처리 구현
+public class LoginInterceptor implements HandlerInterceptor {
+  private final LoginService loginService;
+
+  @Override
+  // 컨트롤러가 호출되기 전에 실행됨
+  public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler)
+      throws UnAuthorizedAccessException {
+    if (isLoginRequiredMethod(handler) && !loginService.isUserLogin()) {
+      throw new UnAuthorizedAccessException();
+    }
+    return true;
+  }
+
+  private boolean isLoginRequiredMethod(Object handler) {
+    // HandlerMethod: @RequestMapping과 그 하위 어노테이션(@GetMapping 등)이 붙은 메소드의 정보를 추상화한 객체
+    // 즉 handler가 매핑된 메소드의 정보고, 그 메소드의 어노테이션에 LoginRequired가 있으면 실행
+    return handler instanceof HandlerMethod
+        && ((HandlerMethod) handler).hasMethodAnnotation(LoginRequired.class);
+  }
+}

--- a/src/main/java/com/techeer/cokkiri/global/resolver/LoginUserArgumentResolver.java
+++ b/src/main/java/com/techeer/cokkiri/global/resolver/LoginUserArgumentResolver.java
@@ -1,0 +1,37 @@
+package com.techeer.cokkiri.global.resolver;
+
+import com.techeer.cokkiri.domain.user.service.LoginService;
+import com.techeer.cokkiri.global.annotation.LoginUser;
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+@Component
+// 파라미터가 있을 때 원하는 값을 바인딩해주는 인터페이스
+public class LoginUserArgumentResolver implements HandlerMethodArgumentResolver {
+  private final LoginService loginService;
+
+  @Override
+  // 현재 파라미터를 resolver가 지원하는지에 대한 boolean 리턴
+  public boolean supportsParameter(MethodParameter methodParameter) {
+    // 메소드의 파라미터가 LoginMember 어노테이션을 달고 있으면 resolver의 지원 대상이됨
+    return methodParameter.hasParameterAnnotation(LoginUser.class);
+  }
+
+  @Override
+  // 실제로 바인딩 할 객체를 return함
+  public Object resolveArgument(
+      MethodParameter methodParameter,
+      ModelAndViewContainer modelAndViewContainer,
+      NativeWebRequest nativeWebRequest,
+      WebDataBinderFactory webDataBinderFactory)
+      throws Exception {
+    return loginService.getLoginUser();
+  }
+}

--- a/src/main/java/com/techeer/cokkiri/global/result/ResultCode.java
+++ b/src/main/java/com/techeer/cokkiri/global/result/ResultCode.java
@@ -10,7 +10,7 @@ public enum ResultCode {
 
   // 도메인 별로 나눠서 관리(ex: User 도메인)
   // user
-  USER_CREATE_SUCCESS("U001", "사용자 생성 성공"),
+  USER_REGISTRATION_SUCCESS("U001", "사용자 등록 성공"),
   ;
 
   private final String code;

--- a/src/main/java/com/techeer/cokkiri/global/result/ResultResponse.java
+++ b/src/main/java/com/techeer/cokkiri/global/result/ResultResponse.java
@@ -13,6 +13,10 @@ public class ResultResponse {
     return new ResultResponse(resultCode, data);
   }
 
+  public static ResultResponse of(ResultCode resultCode) {
+    return new ResultResponse(resultCode, "");
+  }
+
   public ResultResponse(ResultCode resultCode, Object data) {
     this.code = resultCode.getCode();
     this.message = resultCode.getMessage();


### PR DESCRIPTION
## 추가한 기능 설명
- 로그인 상태일때만 api호출이 가능하도록하는 어노테이션 추가
- User 파라미터에 붙혀서 로그인되어있는 User 를 주입하는 어노테이션추가
- 로그인 시 세션에 User의 username을 저장
- swagger를 통해 api 테스트 완료
<img width="423" alt="image" src="https://user-images.githubusercontent.com/108508730/206404293-95b99006-d098-4921-a935-8cf0e53b5692.png">

<br>


## check list
- [x] issue number를 브랜치 앞에 추가 하였는가?
- [ ] 모든 단위 테스트를 돌려보고 기존에 작동하던 테스트에 영향이 없는 것을 확인했는가?
- [ ] [우테코 pr 규칙](https://github.com/woowacourse/woowacourse-docs/blob/master/cleancode/pr_checklist.md)을 준수하였는가?