### PR TITLE
[fix/#26] Study 엔티티의 접근제한자, 유효성 검증 로직 수정 및 전체적인 상태코드 수정

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
-## 추가한 기능 설명
+## 추가/수정한 기능 설명
 
 <br>
 
@@ -6,4 +6,4 @@
 ## check list
 - [ ] issue number를 브랜치 앞에 추가 하였는가?
 - [ ] 모든 단위 테스트를 돌려보고 기존에 작동하던 테스트에 영향이 없는 것을 확인했는가?
-- [ ] [우테코 pr 규칙](https://github.com/woowacourse/woowacourse-docs/blob/master/cleancode/pr_checklist.md)을 준수하였는가?
+- [ ] 추가/수정사항을 설명하였는가?

--- a/src/main/java/com/techeer/cokkiri/domain/study/controller/StudyController.java
+++ b/src/main/java/com/techeer/cokkiri/domain/study/controller/StudyController.java
@@ -10,7 +10,6 @@ import com.techeer.cokkiri.global.annotation.LoginRequired;
 import com.techeer.cokkiri.global.annotation.LoginUser;
 import com.techeer.cokkiri.global.result.ResultResponse;
 import javax.validation.Valid;
-
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;

--- a/src/main/java/com/techeer/cokkiri/domain/study/controller/StudyController.java
+++ b/src/main/java/com/techeer/cokkiri/domain/study/controller/StudyController.java
@@ -10,6 +10,8 @@ import com.techeer.cokkiri.global.annotation.LoginRequired;
 import com.techeer.cokkiri.global.annotation.LoginUser;
 import com.techeer.cokkiri.global.result.ResultResponse;
 import javax.validation.Valid;
+
+import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -17,7 +19,7 @@ import springfox.documentation.annotations.ApiIgnore;
 
 @RestController
 @RequestMapping("api/v1/studies")
-@RequiredArgsConstructor
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public class StudyController {
   private final StudyService studyService;
 

--- a/src/main/java/com/techeer/cokkiri/domain/study/dto/StudyDto.java
+++ b/src/main/java/com/techeer/cokkiri/domain/study/dto/StudyDto.java
@@ -8,7 +8,7 @@ import lombok.*;
 
 public class StudyDto {
   @Builder
-  @AllArgsConstructor(access = AccessLevel.PROTECTED)
+  @AllArgsConstructor(access = AccessLevel.PRIVATE)
   public static class Response {
     private Long id;
     private String studyName;
@@ -16,8 +16,8 @@ public class StudyDto {
 
   @Getter
   @Builder
-  @AllArgsConstructor(access = AccessLevel.PROTECTED)
-  @NoArgsConstructor(access = AccessLevel.PROTECTED)
+  @AllArgsConstructor(access = AccessLevel.PRIVATE)
+  @NoArgsConstructor(access = AccessLevel.PRIVATE)
   public static class Request {
     @NotEmpty private String studyName;
     @Builder.Default private String studyPassword = DEFAULT_PASSWORD; // 추후 인코딩 추가

--- a/src/main/java/com/techeer/cokkiri/domain/study/dto/StudyDto.java
+++ b/src/main/java/com/techeer/cokkiri/domain/study/dto/StudyDto.java
@@ -3,7 +3,7 @@ package com.techeer.cokkiri.domain.study.dto;
 import static com.techeer.cokkiri.domain.study.constant.StudyConstants.*;
 
 import java.time.LocalDate;
-import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.Pattern;
 import lombok.*;
 
 public class StudyDto {
@@ -19,7 +19,9 @@ public class StudyDto {
   @AllArgsConstructor(access = AccessLevel.PRIVATE)
   @NoArgsConstructor(access = AccessLevel.PRIVATE)
   public static class Request {
-    @NotEmpty private String studyName;
+    @Pattern(message = "스터디의 이름은 3자 이상 20자 이하여야 합니다.", regexp = "^.{3,20}$")
+    private String studyName;
+
     @Builder.Default private String studyPassword = DEFAULT_PASSWORD; // 추후 인코딩 추가
     @Builder.Default private Integer userLimit = DEFAULT_USER_LIMIT;
     @Builder.Default private String introduction = DEFAULT_INTRODUCTION;

--- a/src/main/java/com/techeer/cokkiri/domain/study/service/StudyService.java
+++ b/src/main/java/com/techeer/cokkiri/domain/study/service/StudyService.java
@@ -5,11 +5,12 @@ import com.techeer.cokkiri.domain.study.entity.Study;
 import com.techeer.cokkiri.domain.study.mapper.StudyMapper;
 import com.techeer.cokkiri.domain.study.repository.StudyRepository;
 import com.techeer.cokkiri.domain.user.entity.User;
+import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 @Service
-@RequiredArgsConstructor
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public class StudyService {
 
   private final StudyRepository studyRepository;

--- a/src/main/java/com/techeer/cokkiri/global/error/ErrorCode.java
+++ b/src/main/java/com/techeer/cokkiri/global/error/ErrorCode.java
@@ -15,11 +15,11 @@ public enum ErrorCode {
   // User 도메인
   EXAMPLE_USER_ERROR(400, "U001", "테스트용 예시 에러코드"),
   USER_NOT_FOUND_ERROR(400, "U002", "사용자를 찾을 수 없음"),
-  UNAUTHORIZED_ACCESS_ERROR(400, "U003", "승인되지 않은 접근"),
-  USER_USERNAME_DUPLICATED(400, "U004", "회원 아이디 중복"),
+  UNAUTHORIZED_ACCESS_ERROR(403, "U003", "승인되지 않은 접근"),
+  USER_USERNAME_DUPLICATED(409, "U004", "회원 아이디 중복"),
 
   // Study
-  STUDY_DUPLICATION_ERROR(400, "S001", "스터디의 이름이 중복됨");
+  STUDY_DUPLICATION_ERROR(409, "S001", "스터디의 이름이 중복됨");
 
   private final int status;
   private final String code;

--- a/src/main/java/com/techeer/cokkiri/global/error/ErrorCode.java
+++ b/src/main/java/com/techeer/cokkiri/global/error/ErrorCode.java
@@ -13,7 +13,6 @@ public enum ErrorCode {
 
   // 예시
   // User 도메인
-  EXAMPLE_USER_ERROR(400, "U001", "테스트용 예시 에러코드"),
   USER_NOT_FOUND_ERROR(400, "U002", "사용자를 찾을 수 없음"),
   UNAUTHORIZED_ACCESS_ERROR(403, "U003", "승인되지 않은 접근"),
   USER_USERNAME_DUPLICATED(409, "U004", "회원 아이디 중복"),

--- a/src/main/java/com/techeer/cokkiri/global/error/ErrorCode.java
+++ b/src/main/java/com/techeer/cokkiri/global/error/ErrorCode.java
@@ -9,7 +9,7 @@ import lombok.Getter;
 public enum ErrorCode {
   // Global
   INTERNAL_SERVER_ERROR(500, "G001", "서버 오류"),
-  INPUT_INVALID_VALUE(400, "G002", "잘못된 입력"),
+  INPUT_INVALID_VALUE(409, "G002", "잘못된 입력"),
 
   // 예시
   // User 도메인

--- a/src/main/java/com/techeer/cokkiri/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/techeer/cokkiri/global/error/GlobalExceptionHandler.java
@@ -1,7 +1,6 @@
 package com.techeer.cokkiri.global.error;
 
 import static com.techeer.cokkiri.global.error.ErrorCode.INPUT_INVALID_VALUE;
-import static org.springframework.http.HttpStatus.BAD_REQUEST;
 
 import com.techeer.cokkiri.global.error.exception.BusinessException;
 import lombok.extern.slf4j.Slf4j;
@@ -39,6 +38,6 @@ public class GlobalExceptionHandler {
       MethodArgumentNotValidException e) {
     final ErrorResponse response = ErrorResponse.of(INPUT_INVALID_VALUE, e.getBindingResult());
     log.warn(e.getMessage());
-    return new ResponseEntity<>(response, BAD_REQUEST);
+    return ResponseEntity.status(INPUT_INVALID_VALUE.getStatus()).body(response);
   }
 }

--- a/src/main/java/com/techeer/cokkiri/global/error/exception/ExampleException.java
+++ b/src/main/java/com/techeer/cokkiri/global/error/exception/ExampleException.java
@@ -1,9 +1,0 @@
-package com.techeer.cokkiri.global.error.exception;
-
-import com.techeer.cokkiri.global.error.ErrorCode;
-
-public class ExampleException extends BusinessException {
-  public ExampleException() {
-    super(ErrorCode.EXAMPLE_USER_ERROR);
-  }
-}

--- a/src/test/java/com/techeer/cokkiri/global/error/GlobalExceptionHandlerTest.java
+++ b/src/test/java/com/techeer/cokkiri/global/error/GlobalExceptionHandlerTest.java
@@ -62,7 +62,7 @@ class GlobalExceptionHandlerTest {
     mockMvc
         .perform(get("/exception/1"))
         .andExpect(status().isBadRequest())
-        .andExpect(jsonPath("$.businessCode").value(EXAMPLE_USER_ERROR.getCode()))
+        .andExpect(jsonPath("$.businessCode").value(USER_NOT_FOUND_ERROR.getCode()))
         .andDo(print());
   }
 
@@ -98,7 +98,7 @@ class GlobalExceptionHandlerTest {
   static class TestController {
     @GetMapping("/{id}")
     public String executeBusinessException(@PathVariable Long id) {
-      throw new BusinessException(EXAMPLE_USER_ERROR);
+      throw new BusinessException(USER_NOT_FOUND_ERROR);
     }
 
     @PostMapping


### PR DESCRIPTION
## 추가/수정한 기능 설명
Study 도메인의 controller, service, dto 등 생성자의 접근제한자가 protected나 public 으로 설정된 부분 private로 수정

유효성 검증 로직 수정
- 스터디의 이름을 3~20글자로 입력하도록 정규식을 사용

상태코드 수정
- 이름 중복, 형식에 맞지않는 입력 -> 상태코드 409로 수정
- 승인되지 않은 접근 -> 상태코드 403으로 수정

예시로 추가했던 예외 제거 및 관련 로직 수정
<br>


## check list
- [x] issue number를 브랜치 앞에 추가 하였는가?
- [ ] 모든 단위 테스트를 돌려보고 기존에 작동하던 테스트에 영향이 없는 것을 확인했는가?
- [x] 추가/수정사항을 설명하였는가?