### PR TITLE
[fix/#35] 중복되는 DTO이름으로 인해 Swagger에서 잘못된 스키마가 노출되는 오류 수정

### DIFF
--- a/src/main/java/com/techeer/cokkiri/domain/study/dto/StudyDto.java
+++ b/src/main/java/com/techeer/cokkiri/domain/study/dto/StudyDto.java
@@ -4,11 +4,14 @@ import static com.techeer.cokkiri.domain.study.constant.StudyConstants.*;
 
 import java.time.LocalDate;
 import javax.validation.constraints.Pattern;
+
+import io.swagger.annotations.ApiModel;
 import lombok.*;
 
 public class StudyDto {
   @Builder
   @AllArgsConstructor(access = AccessLevel.PRIVATE)
+  @ApiModel(value = "StudyInfoRequest")
   public static class Response {
     private Long id;
     private String studyName;
@@ -18,6 +21,7 @@ public class StudyDto {
   @Builder
   @AllArgsConstructor(access = AccessLevel.PRIVATE)
   @NoArgsConstructor(access = AccessLevel.PRIVATE)
+  @ApiModel(value = "StudyCreateRequest")
   public static class Request {
     @Pattern(message = "스터디의 이름은 3자 이상 20자 이하여야 합니다.", regexp = "^.{3,20}$")
     private String studyName;

--- a/src/main/java/com/techeer/cokkiri/domain/study/dto/StudyDto.java
+++ b/src/main/java/com/techeer/cokkiri/domain/study/dto/StudyDto.java
@@ -2,10 +2,9 @@ package com.techeer.cokkiri.domain.study.dto;
 
 import static com.techeer.cokkiri.domain.study.constant.StudyConstants.*;
 
+import io.swagger.annotations.ApiModel;
 import java.time.LocalDate;
 import javax.validation.constraints.Pattern;
-
-import io.swagger.annotations.ApiModel;
 import lombok.*;
 
 public class StudyDto {

--- a/src/main/java/com/techeer/cokkiri/domain/user/dto/UserDto.java
+++ b/src/main/java/com/techeer/cokkiri/domain/user/dto/UserDto.java
@@ -2,9 +2,8 @@ package com.techeer.cokkiri.domain.user.dto;
 
 import static com.techeer.cokkiri.global.constant.RegExp.PASSWORD_REGEXP;
 
-import javax.validation.constraints.Pattern;
-
 import io.swagger.annotations.ApiModel;
+import javax.validation.constraints.Pattern;
 import lombok.*;
 import org.hibernate.validator.constraints.Length;
 

--- a/src/main/java/com/techeer/cokkiri/domain/user/dto/UserDto.java
+++ b/src/main/java/com/techeer/cokkiri/domain/user/dto/UserDto.java
@@ -3,6 +3,8 @@ package com.techeer.cokkiri.domain.user.dto;
 import static com.techeer.cokkiri.global.constant.RegExp.PASSWORD_REGEXP;
 
 import javax.validation.constraints.Pattern;
+
+import io.swagger.annotations.ApiModel;
 import lombok.*;
 import org.hibernate.validator.constraints.Length;
 
@@ -12,6 +14,7 @@ public class UserDto {
   @Builder
   @AllArgsConstructor(access = AccessLevel.PRIVATE)
   @NoArgsConstructor(access = AccessLevel.PRIVATE)
+  @ApiModel(value = "UserLoginRequest")
   public static class Request {
 
     @Length(max = 20)

--- a/src/main/java/com/techeer/cokkiri/domain/user/dto/UserRegisterRequest.java
+++ b/src/main/java/com/techeer/cokkiri/domain/user/dto/UserRegisterRequest.java
@@ -5,6 +5,8 @@ import static com.techeer.cokkiri.global.constant.RegExp.PASSWORD_REGEXP;
 import javax.validation.constraints.Max;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.Pattern;
+
+import io.swagger.annotations.ApiModel;
 import lombok.*;
 import org.hibernate.validator.constraints.URL;
 
@@ -12,6 +14,7 @@ import org.hibernate.validator.constraints.URL;
 @Builder
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@ApiModel(value = "UserRegisterRequest")
 public class UserRegisterRequest {
 
   @NotBlank(message = "username을 입력해주세요")

--- a/src/main/java/com/techeer/cokkiri/domain/user/dto/UserRegisterRequest.java
+++ b/src/main/java/com/techeer/cokkiri/domain/user/dto/UserRegisterRequest.java
@@ -2,11 +2,10 @@ package com.techeer.cokkiri.domain.user.dto;
 
 import static com.techeer.cokkiri.global.constant.RegExp.PASSWORD_REGEXP;
 
+import io.swagger.annotations.ApiModel;
 import javax.validation.constraints.Max;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.Pattern;
-
-import io.swagger.annotations.ApiModel;
 import lombok.*;
 import org.hibernate.validator.constraints.URL;
 

--- a/src/main/java/com/techeer/cokkiri/global/constant/RegExp.java
+++ b/src/main/java/com/techeer/cokkiri/global/constant/RegExp.java
@@ -1,6 +1,5 @@
 package com.techeer.cokkiri.global.constant;
 
-
 public class RegExp {
   public static final String PASSWORD_REGEXP =
       "^(?=.*[0-9])(?=.*[a-z])(?=.*[A-Z])(?=.*[@#!~$%^&-+=()])(?=\\S+$).{8,16}$";


### PR DESCRIPTION
## 추가/수정한 기능 설명
DTO이름이 중복되어 잘못된 스키마가 나타났던 오류를 ApiModel 어노테이션을 이용하여 해결
<br>


## check list
- [x] issue number를 브랜치 앞에 추가 하였는가?
- [x] 모든 단위 테스트를 돌려보고 기존에 작동하던 테스트에 영향이 없는 것을 확인했는가?
- [x] 추가/수정사항을 설명하였는가?