### PR TITLE
[fix/#39] BaseEntity의 isDelted에 기본값이 제대로 들어가지 않던 오류 수정

### DIFF
--- a/src/main/java/com/techeer/cokkiri/global/entity/BaseEntity.java
+++ b/src/main/java/com/techeer/cokkiri/global/entity/BaseEntity.java
@@ -12,7 +12,6 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Getter
 @MappedSuperclass
-@DynamicInsert
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @EntityListeners(AuditingEntityListener.class)
 @ToString
@@ -21,8 +20,7 @@ public class BaseEntity {
 
   @LastModifiedDate private LocalDateTime updatedAt;
 
-  @Column(columnDefinition = "boolean default false")
-  private Boolean isDeleted;
+  private boolean isDeleted;
 
   public void deleteEntity() {
     this.isDeleted = true;

--- a/src/main/java/com/techeer/cokkiri/global/entity/BaseEntity.java
+++ b/src/main/java/com/techeer/cokkiri/global/entity/BaseEntity.java
@@ -1,11 +1,9 @@
 package com.techeer.cokkiri.global.entity;
 
 import java.time.LocalDateTime;
-import javax.persistence.Column;
 import javax.persistence.EntityListeners;
 import javax.persistence.MappedSuperclass;
 import lombok.*;
-import org.hibernate.annotations.DynamicInsert;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;


### PR DESCRIPTION
## 추가/수정한 기능 설명
BaseEntity의 isDeleted의 기본값이 null로 들어가던 오류를 수정함
<br>


## check list
- [ ] issue number를 브랜치 앞에 추가 하였는가?
- [ ] 모든 단위 테스트를 돌려보고 기존에 작동하던 테스트에 영향이 없는 것을 확인했는가?
- [ ] 추가/수정사항을 설명하였는가?