### PR TITLE
[feat/#47] 스터디 최신순 페이징 조회 API 구현

### DIFF
--- a/src/main/java/com/techeer/cokkiri/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/techeer/cokkiri/domain/comment/controller/CommentController.java
@@ -28,7 +28,7 @@ public class CommentController {
   @LoginRequired
   @PostMapping
   public ResponseEntity<ResultResponse> createComment(
-          @Valid @RequestBody CommentDto.CreateRequest request, @ApiIgnore @LoginUser User user) {
+      @Valid @RequestBody CommentDto.CreateRequest request, @ApiIgnore @LoginUser User user) {
 
     Study study = studyService.findByStudyId(request.getStudyId());
 

--- a/src/main/java/com/techeer/cokkiri/domain/comment/dto/CommentDto.java
+++ b/src/main/java/com/techeer/cokkiri/domain/comment/dto/CommentDto.java
@@ -1,9 +1,7 @@
 package com.techeer.cokkiri.domain.comment.dto;
 
 import com.techeer.cokkiri.domain.user.dto.UserDto;
-
 import javax.validation.constraints.*;
-
 import lombok.*;
 
 public class CommentDto {

--- a/src/main/java/com/techeer/cokkiri/domain/study/controller/StudyController.java
+++ b/src/main/java/com/techeer/cokkiri/domain/study/controller/StudyController.java
@@ -1,5 +1,7 @@
 package com.techeer.cokkiri.domain.study.controller;
 
+import static com.techeer.cokkiri.global.result.ResultCode.*;
+
 import com.techeer.cokkiri.domain.study.dto.StudyDto;
 import com.techeer.cokkiri.domain.study.exception.StudyDuplicationException;
 import com.techeer.cokkiri.domain.study.service.StudyService;
@@ -8,6 +10,7 @@ import com.techeer.cokkiri.global.annotation.LoginRequired;
 import com.techeer.cokkiri.global.annotation.LoginUser;
 import com.techeer.cokkiri.global.result.ResultResponse;
 import io.swagger.annotations.ApiOperation;
+import java.util.List;
 import javax.validation.Valid;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
@@ -16,10 +19,6 @@ import org.springframework.data.domain.Sort;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import springfox.documentation.annotations.ApiIgnore;
-
-import java.util.List;
-
-import static com.techeer.cokkiri.global.result.ResultCode.*;
 
 @RestController
 @RequestMapping("api/v1/studies")

--- a/src/main/java/com/techeer/cokkiri/domain/study/controller/StudyController.java
+++ b/src/main/java/com/techeer/cokkiri/domain/study/controller/StudyController.java
@@ -1,8 +1,5 @@
 package com.techeer.cokkiri.domain.study.controller;
 
-import static com.techeer.cokkiri.global.result.ResultCode.STUDY_CREATE_SUCCESS;
-import static com.techeer.cokkiri.global.result.ResultCode.STUDY_GET_SUCCESS;
-
 import com.techeer.cokkiri.domain.study.dto.StudyDto;
 import com.techeer.cokkiri.domain.study.exception.StudyDuplicationException;
 import com.techeer.cokkiri.domain.study.service.StudyService;
@@ -14,9 +11,15 @@ import io.swagger.annotations.ApiOperation;
 import javax.validation.Valid;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import springfox.documentation.annotations.ApiIgnore;
+
+import java.util.List;
+
+import static com.techeer.cokkiri.global.result.ResultCode.*;
 
 @RestController
 @RequestMapping("api/v1/studies")
@@ -40,5 +43,15 @@ public class StudyController {
   public ResponseEntity<ResultResponse> findStudyByStudyId(@PathVariable Long studyId) {
     StudyDto.FindResponse studyResponse = studyService.findStudyDtoById(studyId);
     return ResponseEntity.ok(ResultResponse.of(STUDY_GET_SUCCESS, studyResponse));
+  }
+
+  @ApiOperation(value = "스터디 최신순 페이징 조회")
+  @GetMapping("/page/{page}")
+  public ResponseEntity<ResultResponse> getStudyListWithPagingNewest(
+      @PathVariable Integer page, @RequestParam(defaultValue = "20") Integer size) {
+    PageRequest pageRequest = PageRequest.of(page, size, Sort.by("id").descending());
+    List<StudyDto.InfoResponse> studyInfoResponseList =
+        studyService.getStudyListWithPaging(pageRequest);
+    return ResponseEntity.ok(ResultResponse.of(STUDY_PAGING_GET_SUCCESS, studyInfoResponseList));
   }
 }

--- a/src/main/java/com/techeer/cokkiri/domain/study/dto/StudyDto.java
+++ b/src/main/java/com/techeer/cokkiri/domain/study/dto/StudyDto.java
@@ -10,10 +10,11 @@ import javax.validation.constraints.Pattern;
 import lombok.*;
 
 public class StudyDto {
+  @Getter
   @Builder
   @AllArgsConstructor(access = AccessLevel.PRIVATE)
   @ApiModel(value = "StudyInfoRequest")
-  public static class Response {
+  public static class InfoResponse {
     private Long id;
     private String studyName;
   }

--- a/src/main/java/com/techeer/cokkiri/domain/study/mapper/StudyMapper.java
+++ b/src/main/java/com/techeer/cokkiri/domain/study/mapper/StudyMapper.java
@@ -15,8 +15,8 @@ public class StudyMapper {
 
   private UserMapper userMapper = new UserMapper();
 
-  public Response toDto(Study study) {
-    return Response.builder().studyName(study.getStudyName()).build();
+  public InfoResponse toDto(Study study) {
+    return InfoResponse.builder().id(study.getId()).studyName(study.getStudyName()).build();
   }
 
   public Study toEntity(Request dto, User manager) {
@@ -35,7 +35,7 @@ public class StudyMapper {
     return study;
   }
 
-  public StudyDto.FindResponse toStudyDto(Study study, List<User> users) {
+  public StudyDto.FindResponse toDto(Study study, List<User> users) {
 
     StudyDto.FindResponse studyFindResponse =
         StudyDto.FindResponse.builder()
@@ -51,7 +51,7 @@ public class StudyMapper {
     return studyFindResponse;
   }
 
-  public List<Response> toDtoList(List<Study> list) {
+  public List<InfoResponse> toDtoList(List<Study> list) {
     return list.stream().map(this::toDto).collect(Collectors.toList());
   }
 }

--- a/src/main/java/com/techeer/cokkiri/domain/study/mapper/StudyMapper.java
+++ b/src/main/java/com/techeer/cokkiri/domain/study/mapper/StudyMapper.java
@@ -8,6 +8,7 @@ import com.techeer.cokkiri.domain.user.entity.User;
 import com.techeer.cokkiri.domain.user.mapper.UserMapper;
 import java.util.List;
 import java.util.stream.Collectors;
+import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -53,5 +54,9 @@ public class StudyMapper {
 
   public List<InfoResponse> toDtoList(List<Study> list) {
     return list.stream().map(this::toDto).collect(Collectors.toList());
+  }
+
+  public Page<InfoResponse> toDtoList(Page<Study> studyList) {
+    return studyList.map(this::toDto);
   }
 }

--- a/src/main/java/com/techeer/cokkiri/domain/study/repository/StudyRepository.java
+++ b/src/main/java/com/techeer/cokkiri/domain/study/repository/StudyRepository.java
@@ -1,9 +1,8 @@
 package com.techeer.cokkiri.domain.study.repository;
 
 import com.techeer.cokkiri.domain.study.entity.Study;
-import org.springframework.data.jpa.repository.JpaRepository;
-
 import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface StudyRepository extends JpaRepository<Study, Long> {
   boolean existsByStudyName(String studyName);

--- a/src/main/java/com/techeer/cokkiri/domain/study/service/StudyService.java
+++ b/src/main/java/com/techeer/cokkiri/domain/study/service/StudyService.java
@@ -43,7 +43,7 @@ public class StudyService {
 
     Study study = studyRepository.findById(studyId).orElseThrow(StudyNotFoundException::new);
     List<User> studyMembers = userStudyRepository.findByStudyId(studyId);
-    StudyDto.FindResponse studyFindResponse = studyMapper.toStudyDto(study, studyMembers);
+    StudyDto.FindResponse studyFindResponse = studyMapper.toDto(study, studyMembers);
 
     return studyFindResponse;
   }

--- a/src/main/java/com/techeer/cokkiri/domain/study/service/StudyService.java
+++ b/src/main/java/com/techeer/cokkiri/domain/study/service/StudyService.java
@@ -7,10 +7,11 @@ import com.techeer.cokkiri.domain.study.mapper.StudyMapper;
 import com.techeer.cokkiri.domain.study.repository.StudyRepository;
 import com.techeer.cokkiri.domain.study.repository.UserStudyRepository;
 import com.techeer.cokkiri.domain.user.entity.User;
-import com.techeer.cokkiri.domain.user.mapper.UserMapper;
 import java.util.List;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -20,7 +21,6 @@ public class StudyService {
   private final StudyRepository studyRepository;
   private final UserStudyRepository userStudyRepository;
   private final StudyMapper studyMapper;
-  private final UserMapper userMapper;
 
   public Study createStudy(StudyDto.Request requestDto, User loginUser) { // 스터디 등록
     Study study = studyMapper.toEntity(requestDto, loginUser);
@@ -46,5 +46,10 @@ public class StudyService {
     StudyDto.FindResponse studyFindResponse = studyMapper.toDto(study, studyMembers);
 
     return studyFindResponse;
+  }
+
+  public List<StudyDto.InfoResponse> getStudyListWithPaging(PageRequest pageRequest) {
+    Page<Study> studyPages = studyRepository.findAll(pageRequest);
+    return studyMapper.toDtoList(studyPages).getContent();
   }
 }

--- a/src/main/java/com/techeer/cokkiri/global/result/ResultCode.java
+++ b/src/main/java/com/techeer/cokkiri/global/result/ResultCode.java
@@ -19,9 +19,12 @@ public enum ResultCode {
   // study
   STUDY_CREATE_SUCCESS("S001", "스터디 생성 성공"),
   STUDY_GET_SUCCESS("S002", "스터디 조회 성공"),
+  STUDY_PAGING_GET_SUCCESS("S003", "스터디 페이징 조회 성공"),
+
   // comment
   REGISTER_COMMENT_SUCCESS("C001", "댓글 등록 성공"),
-  COMMENT_FIND_SUCCESS("C002", "댓글 찾기 성공");
+  COMMENT_FIND_SUCCESS("C002", "댓글 찾기 성공"),
+  ;
 
   private final String code;
   private final String message;


### PR DESCRIPTION
## 추가/수정한 기능 설명
<img width="390" alt="image" src="https://user-images.githubusercontent.com/108508730/210247131-3be9e8b0-2a53-406f-ae97-05699a251abf.png">
페이지 번호를 path variable로 받고, 한 페이지당 넘겨줄 데이터 수를 쿼리파라미터로 받는다.

ex1) ~page/2?size=2 -> 전체 데이터를 각 페이지가 2개가 되도록 나눔 -> 첫번째부터 여섯번째까지 데이터를 넣었으면 두번째와 첫번째로 넣은 데이터가 보인다.

ex2) ~page/0?size=2(위 사진과 동일) -> 여섯번째와 다섯번째로 넣은 데이터가 보인다.

+ size를 넣지 않으면 기본 값인 20이 들어간다.
<br>


## check list
- [x] issue number를 브랜치 앞에 추가 하였는가?
- [ ] 모든 단위 테스트를 돌려보고 기존에 작동하던 테스트에 영향이 없는 것을 확인했는가?
- [x] 추가/수정사항을 설명하였는가?