### PR TITLE
[feat/#64] 스터디 조회시 스터디의 상태도 함께 반환하는 기능 추가

### DIFF
--- a/src/main/java/com/techeer/cokkiri/domain/study/dto/StudyDto.java
+++ b/src/main/java/com/techeer/cokkiri/domain/study/dto/StudyDto.java
@@ -22,6 +22,7 @@ public class StudyDto {
     private String introduction;
     private LocalDate startDate;
     private LocalDate finishDate;
+    private String studyStatus;
   }
 
   @Getter
@@ -53,5 +54,6 @@ public class StudyDto {
     private String introduction;
     private Integer studyCycle;
     private LocalDate finishDate;
+    private String studyStatus;
   }
 }

--- a/src/main/java/com/techeer/cokkiri/domain/study/entity/Study.java
+++ b/src/main/java/com/techeer/cokkiri/domain/study/entity/Study.java
@@ -71,4 +71,14 @@ public class Study extends BaseEntity {
   public Integer getStudyUserCount() {
     return users.size();
   }
+
+  public StudyStatus getStudyStatus() {
+    if (LocalDate.now().isBefore(startDate)) {
+      return StudyStatus.RECRUITING;
+    }
+    if (LocalDate.now().isAfter(finishDate)) {
+      return StudyStatus.FINISH;
+    }
+    return StudyStatus.IN_PROGRESS;
+  }
 }

--- a/src/main/java/com/techeer/cokkiri/domain/study/entity/StudyStatus.java
+++ b/src/main/java/com/techeer/cokkiri/domain/study/entity/StudyStatus.java
@@ -1,0 +1,14 @@
+package com.techeer.cokkiri.domain.study.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum StudyStatus {
+    RECRUITING("모집 중"),
+    IN_PROGRESS("진행 중"),
+    FINISH("종료");
+
+    private final String status;
+}

--- a/src/main/java/com/techeer/cokkiri/domain/study/entity/StudyStatus.java
+++ b/src/main/java/com/techeer/cokkiri/domain/study/entity/StudyStatus.java
@@ -6,9 +6,9 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public enum StudyStatus {
-    RECRUITING("모집 중"),
-    IN_PROGRESS("진행 중"),
-    FINISH("종료");
+  RECRUITING("모집 중"),
+  IN_PROGRESS("진행 중"),
+  FINISH("종료");
 
-    private final String status;
+  private final String status;
 }

--- a/src/main/java/com/techeer/cokkiri/domain/study/mapper/StudyMapper.java
+++ b/src/main/java/com/techeer/cokkiri/domain/study/mapper/StudyMapper.java
@@ -25,6 +25,7 @@ public class StudyMapper {
         .startDate(study.getStartDate())
         .finishDate(study.getFinishDate())
         .introduction(study.getIntroduction())
+        .studyStatus(study.getStudyStatus().getStatus())
         .build();
   }
 
@@ -55,6 +56,7 @@ public class StudyMapper {
             .introduction(study.getIntroduction())
             .studyCycle(study.getStudyCycle())
             .finishDate(study.getFinishDate())
+            .studyStatus(study.getStudyStatus().getStatus())
             .build();
 
     return studyFindResponse;

--- a/src/main/java/com/techeer/cokkiri/domain/study/repository/UserStudyRepository.java
+++ b/src/main/java/com/techeer/cokkiri/domain/study/repository/UserStudyRepository.java
@@ -4,7 +4,10 @@ import com.techeer.cokkiri.domain.user.entity.User;
 import com.techeer.cokkiri.domain.user.entity.UserStudy;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface UserStudyRepository extends JpaRepository<UserStudy, Long> {
-  List<User> findByStudyId(Long studyId);
+  @Query("SELECT u FROM User u JOIN u.studies us WHERE us.study.id = :studyId")
+  List<User> findByStudyId(@Param("studyId") Long studyId);
 }


### PR DESCRIPTION
## 추가/수정한 기능 설명
스터디 조회시 스터디의 상태(모집 중, 진행 중, 종료)도 함께 반환하는 기능 추가 및 스터디Id로 해당 스터디의 user들을 가져오는 부분 오류 수정
<br>


## check list
- [ ] issue number를 브랜치 앞에 추가 하였는가?
- [ ] 모든 단위 테스트를 돌려보고 기존에 작동하던 테스트에 영향이 없는 것을 확인했는가?
- [ ] 추가/수정사항을 설명하였는가?